### PR TITLE
feat: Decades

### DIFF
--- a/controllers/getFromDB.ts
+++ b/controllers/getFromDB.ts
@@ -673,6 +673,72 @@ export async function findArtistsWithinDegrees(
     return results;
 }
 
+function buildDecadeCondition(startYear: number, endYear: number) {
+    return {
+        $and: [
+            { $lte: [{ $toInt: { $substr: ["$startDate", 0, 4] } }, endYear] },
+            {
+                $or: [
+                    { $not: { $gt: [{ $strLenCP: { $ifNull: ["$endDate", ""] } }, 3] } },
+                    { $gte: [{ $toInt: { $substr: ["$endDate", 0, 4] } }, startYear] }
+                ]
+            }
+        ]
+    };
+}
+
+export async function getArtistsByDecades(
+    decades: string[],
+    filter: FilterField,
+    amount: number,
+    genreIDs?: string[]
+) {
+    const decadeConditions = decades.map(d => {
+        const startYear = parseInt(d.replace('s', ''));
+        return buildDecadeCondition(startYear, startYear + 9);
+    });
+
+    const matchStage: Record<string, unknown> = {
+        startDate: { $exists: true, $nin: [null, ""] },
+        [filter]: { $type: "number" },
+        $expr: {
+            $and: [
+                { $gt: [{ $strLenCP: "$startDate" }, 3] },
+                decadeConditions.length === 1 ? decadeConditions[0] : { $or: decadeConditions }
+            ]
+        }
+    };
+
+    if (genreIDs?.length) {
+        matchStage.genres = { $in: genreIDs };
+    }
+
+    const artists = await collections.artists
+        ?.find(matchStage)
+        .sort({ [filter]: -1 })
+        .limit(amount)
+        .toArray();
+
+    const countMatch: Record<string, unknown> = {
+        startDate: { $exists: true, $nin: [null, ""] },
+        $expr: {
+            $and: [
+                { $gt: [{ $strLenCP: "$startDate" }, 3] },
+                decadeConditions.length === 1 ? decadeConditions[0] : { $or: decadeConditions }
+            ]
+        }
+    };
+    if (genreIDs?.length) countMatch.genres = { $in: genreIDs };
+
+    const count = await collections.artists?.countDocuments(countMatch);
+
+    return {
+        artists,
+        count,
+        links: createArtistLinksLessCPU(artists as unknown as Artist[]),
+    };
+}
+
 export async function verifyAccessCode(code: string, userEmail: string) {
     const accessCode = await collections.accessCodes?.findOne({ userEmail: userEmail.toLowerCase() });
     const isValid = accessCode ? accessCode.code === code || accessCode.accessed : false;

--- a/routes/artists.ts
+++ b/routes/artists.ts
@@ -3,6 +3,7 @@ import {
     getArtistByName,
     getArtistDataFiltered,
     getArtistFromID,
+    getArtistsByDecades,
     getDuplicateArtists, getDuplicateArtistsNames,
     getGenreArtistData,
     getMultipleArtists,
@@ -247,6 +248,27 @@ router.post('/filtered-genres', async (req, res) => {
     } catch (err) {
         console.error('Failed to fetch artists from genres:', err);
         res.status(500).json({ error: 'Failed to fetch artists from genres' });
+    }
+});
+
+// Fetches artists active during the given decades, optionally filtered by genre
+router.post('/by-decades', async (req, res) => {
+    const { decades, filter, amount, genres } = req.body;
+    if (!decades?.length || !filter || !amount || parseInt(amount) < 1) {
+        res.status(400).json({ error: 'Invalid request body' });
+        return;
+    }
+    try {
+        const artistData = await getArtistsByDecades(
+            decades,
+            filter as FilterField,
+            parseInt(amount),
+            genres
+        );
+        res.json(artistData);
+    } catch (err) {
+        console.error('Failed to fetch artists by decades:', err);
+        res.status(500).json({ error: 'Failed to fetch artists by decades' });
     }
 });
 


### PR DESCRIPTION
## Changes
- New function `getArtistsByDecades` in `controllers/getFromDB.ts`: builds `$expr`-based MongoDB query using `$substr`/`$toInt` year extraction with endDate null guards
- New route `POST /artists/by-decades` in `routes/artists.ts`: accepts `{ decades: string[], filter, amount, genres? }`, returns `{ artists, count, links }`

### Design Decisions
- **"Active during" semantics**: Decade filter uses `startDate ≤ decade_end AND (no endDate OR endDate ≥ decade_start)` rather than strict birth/formation decade matching. This ensures artists like Led Zeppelin (formed 1968) appear in 1970s results. Known limitation: MusicBrainz uses birth year (not career start) for person artists, so modern high-listener artists born in a decade will also surface. Accepted as a data model constraint.
- **Genre + decade composability**: The endpoint accepts an optional `genres` field so decade filtering composes with the existing genre filter rather than replacing it.