### PR TITLE
Bug/search improvement

### DIFF
--- a/controllers/getFromDB.ts
+++ b/controllers/getFromDB.ts
@@ -204,6 +204,13 @@ export async function searchDB(query: string, limit = 10) {
         .sort((a, b) => (b.searchScore ?? 0) - (a.searchScore ?? 0));
 }
 
+// Returns one random artist or genre (even odds) for the "Surprise Me" action
+export async function getRandomNode() {
+    const collection = Math.random() < 0.5 ? collections.artists : collections.genres;
+    const result = await collection?.aggregate([{ $sample: { size: 1 } }]).toArray();
+    return result?.[0] ?? null;
+}
+
 export async function matchArtistNameInDB(query: string, limit = 10) {
     const searchQuery = [{ $search: { text: { query, path: "name" }, index: "name" } }, { $limit: limit }];
     return collections.artists?.aggregate(searchQuery).toArray();

--- a/controllers/getFromDB.ts
+++ b/controllers/getFromDB.ts
@@ -175,13 +175,33 @@ export async function getSimilarArtistsFromArray(artists: string[]) {
     return similarArtists;
 }
 
-export async function searchDB(query: string) {
-    const searchQuery = { $text: { $search: query } };
-    let genreResults = await collections.genres?.find(searchQuery).limit(10).toArray();
-    let artistResults = await collections.artists?.find(searchQuery).limit(10).toArray();
-    if (!genreResults) genreResults = [];
-    if (!artistResults) artistResults = [];
-    return [...artistResults, ...genreResults];
+export async function searchDB(query: string, limit = 10) {
+    // Prefix matching while typing (autocomplete) plus whole-word typo tolerance (text + fuzzy),
+    // with exact names boosted to the top
+    const searchPipeline = (index: string) => [
+        {
+            $search: {
+                index,
+                compound: {
+                    should: [
+                        { autocomplete: { query, path: "name", score: { boost: { value: 3 } } } },
+                        { autocomplete: { query, path: "name", fuzzy: { maxEdits: 1, prefixLength: 1 } } },
+                        { text: { query, path: "name", fuzzy: { maxEdits: 1, prefixLength: 1 }, score: { boost: { value: 2 } } } },
+                        { phrase: { query, path: "name", score: { boost: { value: 5 } } } },
+                    ],
+                    minimumShouldMatch: 1,
+                },
+            },
+        },
+        { $limit: limit },
+        { $addFields: { searchScore: { $meta: "searchScore" } } },
+    ];
+    const [artistResults, genreResults] = await Promise.all([
+        collections.artists?.aggregate(searchPipeline("name")).toArray(),
+        collections.genres?.aggregate(searchPipeline("genreName")).toArray(),
+    ]);
+    return [...(artistResults ?? []), ...(genreResults ?? [])]
+        .sort((a, b) => (b.searchScore ?? 0) - (a.searchScore ?? 0));
 }
 
 export async function matchArtistNameInDB(query: string, limit = 10) {

--- a/routes/search.ts
+++ b/routes/search.ts
@@ -1,7 +1,17 @@
 import express from "express";
-import {searchDB} from "../controllers/getFromDB";
+import {searchDB, getRandomNode} from "../controllers/getFromDB";
 
 const router = express.Router();
+
+router.get('/random/node', async (req, res) => {
+    try {
+        const result = await getRandomNode();
+        res.json(result);
+    } catch (err) {
+        console.error('Failed to get random node:', err);
+        res.status(500).json({ error: 'Failed to get random node' });
+    }
+});
 
 router.get('/:query',async (req, res) => {
     try {


### PR DESCRIPTION
## Changes
Related to front end features for search improvements and Surprise Me

- Rewrote `searchDB` in `controllers/getFromDB.ts` — compound `$search` pipeline with `autocomplete`, `fuzzy`, `text`, and `phrase` operators; results from artists and genres collections merged and sorted by `searchScore`
- Added `getRandomNode()` — samples one document at random from either the artists or genres collection via `$sample`
- Added `GET /search/random/node` route (registered before `/:query` to avoid being swallowed by the param route)
- Updated Atlas Search indexes for both collections: `autocomplete` tokenizer with edgeGram strategy, minGrams 2, maxGrams 15, foldDiacritics enabled