### PR TITLE
Add /ai/label-clusters endpoint for cluster labeling

### DIFF
--- a/controllers/labelClusters.ts
+++ b/controllers/labelClusters.ts
@@ -1,0 +1,53 @@
+import type { Request, Response } from 'express';
+
+export async function labelClusters(req: Request, res: Response) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    res.status(503).json({ error: 'AI labeling not configured' });
+    return;
+  }
+
+  const { clusters } = req.body;
+  if (!Array.isArray(clusters) || clusters.length === 0) {
+    res.status(400).json({ error: 'clusters array required' });
+    return;
+  }
+
+  const clusterList = clusters
+    .map(({ id, tags }: { id: string; tags: string[] }) => `"${id}": [${tags.join(', ')}]`)
+    .join('\n');
+
+  const prompt = `You are a music genre expert. Each entry below is a cluster of listeners grouped by their most common Last.fm tags. Give each cluster a concise name (1–3 words) that captures the musical subculture or sound scene — not just the genre name, but the vibe or scene if it fits.
+
+Clusters (ID → top listener tags):
+${clusterList}
+
+Return only a JSON object mapping each cluster ID to its label. Example: {"id1": "Thrash Metal", "id2": "Ambient Drone"}`;
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: prompt }],
+        response_format: { type: 'json_object' },
+        temperature: 0.2,
+      }),
+    });
+
+    if (!response.ok) {
+      res.status(502).json({ error: `OpenAI API error: ${response.status}` });
+      return;
+    }
+
+    const data = await response.json();
+    const labels = JSON.parse(data.choices[0].message.content);
+    res.json({ labels });
+  } catch {
+    res.status(502).json({ error: 'Failed to generate cluster labels' });
+  }
+}

--- a/routes/ai.ts
+++ b/routes/ai.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { labelClusters } from '../controllers/labelClusters';
+
+const router = express.Router();
+
+router.post('/label-clusters', labelClusters);
+
+export default router;

--- a/server.ts
+++ b/server.ts
@@ -7,6 +7,7 @@ import search from "./routes/search";
 import initializeDB from "./routes/dbInit";
 import users from "./routes/users";
 import admin from "./routes/admin";
+import ai from "./routes/ai";
 import {connectDB} from "./db/connection";
 import {auth} from "./utils/auth";
 import { toNodeHandler } from "better-auth/node";
@@ -29,6 +30,7 @@ app.use('/search', search);
 app.use('/initializeDB', initializeDB);
 app.use('/users', users);
 app.use('/admin', admin);
+app.use('/ai', ai);
 
 app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);


### PR DESCRIPTION
## Summary
- New `POST /ai/label-clusters` endpoint that accepts cluster tag data and calls OpenAI server-side
- Moves the OpenAI API call out of the frontend, where the key was being leaked via Vite's client bundle

Pairs with https://github.com/Chonathon/rhizome/pull/207

## Files
- `controllers/labelClusters.ts` — handler that builds the prompt and calls OpenAI
- `routes/ai.ts` — route definition
- `server.ts` — registers the `/ai` route

## Deploy notes
- Add `OPENAI_API_KEY` to the server's environment variables (Railway)
- OpenAI account needs active billing — the previous key was revoked and quota was exhausted

## Test plan
- [ ] `curl -X POST <server>/ai/label-clusters -H 'Content-Type: application/json' -d '{"clusters":[{"id":"test","tags":["rock","indie"]}]}'` returns labels
- [ ] Returns 503 gracefully when no API key is configured
- [ ] Returns 400 for missing/empty clusters array